### PR TITLE
[FIX] grap_change_base_product_mass_addition : 3 fixes

### DIFF
--- a/grap_change_base_product_mass_addition/views/view_product_product.xml
+++ b/grap_change_base_product_mass_addition/views/view_product_product.xml
@@ -18,7 +18,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="lst_price" position="replace"/>
             <field name="standard_price" position="replace"/>
             <field name="qty_to_process" position="after">
-                <field name="uom_po_id" string="Purchase UoM"/>
+                <field name="uom_po_id" string="Purchase UoM" readonly="1"/>
             </field>
             <field name="incoming_qty" position="after">
                 <field name="mass_addition_purchase_package_qty" string="Package Qty"


### PR DESCRIPTION
- [FIX] grap_change_base_product_mass_addition : set correct code and name regarding supplier informations ; 
- [FIX] do not allow possibility to edit uom_po via the UI ; 
- [FIX] do not crash if price_unit is not defined