### PR TITLE
IMP precision

### DIFF
--- a/grap_change_precision/data/decimal_precision.xml
+++ b/grap_change_precision/data/decimal_precision.xml
@@ -15,6 +15,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="digits">3</field>
     </record>
 
+    <record id="decimal_invoice_price" model="decimal.precision">
+        <field name="name">GRAP Invoice Price Unit</field>
+        <field name="digits">4</field>
+    </record>
+
     <record id="decimal_volume" model="decimal.precision">
         <field name="name">GRAP Stock Volume</field>
         <field name="digits">3</field>

--- a/grap_change_precision/models/account_invoice_line.py
+++ b/grap_change_precision/models/account_invoice_line.py
@@ -21,3 +21,7 @@ class AccountInvoiceLine(models.Model):
     margin_signed = fields.Float(
         digits=dp.get_precision("GRAP Cost Price")
     )
+
+    price_unit = fields.Float(
+        digits=dp.get_precision("GRAP Invoice Price Unit")
+    )


### PR DESCRIPTION
Je propose une précision à 4 car dans le calcul de sous-total sur le PO, Odoo calcule à une précision à 5.
ça me paraît être le compromis.

Ce qui est "con" , c'est qu'Odoo calcule un prix unitaire dans le calcul de sous-total dans la facture avant de le multiplier, et que ce prix unitaire est arrondi avec ce digit. Bref, avec 4, les cas "bloquants" relevés par les actis sont résolvables

board/144/card/1119
board/144/card/1175