### PR TITLE
 [IMP] grap_change_views_pos: date of statement of cash moves are now the date of the close of the session, if the session is in a closing state

### DIFF
--- a/grap_change_views_pos/__init__.py
+++ b/grap_change_views_pos/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from . import wizards

--- a/grap_change_views_pos/__manifest__.py
+++ b/grap_change_views_pos/__manifest__.py
@@ -14,6 +14,7 @@
         "pos_multicompany",
         "pos_margin",
         "pos_cash_rounding",
+        "pos_cash_move_reason",
     ],
     "data": [
         "views/view_account_bank_statement.xml",

--- a/grap_change_views_pos/readme/DESCRIPTION.rst
+++ b/grap_change_views_pos/readme/DESCRIPTION.rst
@@ -10,3 +10,9 @@
 **Create new view**
 
 * "Point of sale > Order Lines"
+
+
+**Alter module Pos Cash Move Reason**
+
+* Statement lines (of cash moves) has now the date of the close of the session, if it
+  is in a closing state. (Today otherwise)

--- a/grap_change_views_pos/wizards/__init__.py
+++ b/grap_change_views_pos/wizards/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_pos_move_reason

--- a/grap_change_views_pos/wizards/wizard_pos_move_reason.py
+++ b/grap_change_views_pos/wizards/wizard_pos_move_reason.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021-Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class WizardPosMoveReason(models.TransientModel):
+    _inherit = 'wizard.pos.move.reason'
+
+    @api.multi
+    def _prepare_statement_line(self):
+        res = super()._prepare_statement_line()
+        if self.session_id.stop_at:
+            res["date"] = self.session_id.stop_at
+        return res


### PR DESCRIPTION

apps/deck/#/board/144/card/1308

CC : @quentinDupont 