### PR TITLE
[IMP] Product form origin and more

### DIFF
--- a/grap_change_access/security/ir_model_access.xml
+++ b/grap_change_access/security/ir_model_access.xml
@@ -23,6 +23,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <value eval="{'group_id': ref('base.group_erp_manager')}"/>
     </function>
 
+    <!-- res.country.group can be changed only by erp_manager -->
+    <function model="ir.model.access" name="write">
+        <value model="ir.model.access" search="[('id', '=', obj().env.ref('base.access_res_country_group_group_user').id)]"/>
+        <value eval="{'group_id': ref('base.group_erp_manager')}"/>
+    </function>
+
     <!-- res.bank can NOT be changed by Contact Creation -->
     <function model="ir.model.access" name="write">
         <value model="ir.model.access" search="[('id', '=', obj().env.ref('base.access_res_bank_group_partner_manager').id)]"/>

--- a/grap_change_data/__manifest__.py
+++ b/grap_change_data/__manifest__.py
@@ -20,6 +20,7 @@
         "data/barcode_nomenclature.xml",
         "data/product_category.xml",
         "data/product_product.xml",
+        "data/res_country_group.xml",
         "data/uom_uom.xml",
     ],
     "installable": True,

--- a/grap_change_data/data/res_country_group.xml
+++ b/grap_change_data/data/res_country_group.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+@author: Quentin DUPONT (quentin.dupont@grap.coop)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <!-- Rename data -->
+    <function model="res.country.group" name="write">
+        <value eval="[ref('base.europe')]"/>
+        <value eval="{'name': 'Union Européenne'}"/>
+    </function>
+
+    <function model="res.country.group" name="write">
+        <value eval="[ref('base.south_america')]"/>
+        <value eval="{'name': 'Amérique du Sud'}"/>
+    </function>
+
+</odoo>

--- a/grap_change_translation/models/__init__.py
+++ b/grap_change_translation/models/__init__.py
@@ -22,6 +22,7 @@ from . import product_template
 from . import product_template_attribute_value
 from . import res_company
 from . import res_config_settings
+from . import res_country_group
 from . import res_partner_category
 from . import sale_order_template_line
 from . import stock_location_route

--- a/grap_change_translation/models/res_country_group.py
+++ b/grap_change_translation/models/res_country_group.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+# @author: Quentin DUPONT (quentin.dupont@grap.coop)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class ResCountryGroup(models.Model):
+    _inherit = "res.country.group"
+
+    name = fields.Text(translate=False)

--- a/grap_change_views_product/i18n/fr.po
+++ b/grap_change_views_product/i18n/fr.po
@@ -42,11 +42,6 @@ msgstr "Composition alimentaire"
 
 #. module: grap_change_views_product
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
-msgid "Alimentary Information"
-msgstr "Information alimentaire"
-
-#. module: grap_change_views_product
-#: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
 msgid "Allergens"
 msgstr "Allergènes"
 
@@ -201,16 +196,6 @@ msgstr "Qté min."
 
 #. module: grap_change_views_product
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
-msgid "Notations"
-msgstr ""
-
-#. module: grap_change_views_product
-#: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
-msgid "Origin"
-msgstr "Origine"
-
-#. module: grap_change_views_product
-#: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
 msgid "POS Sector"
 msgstr "Secteur du PdV"
 
@@ -223,6 +208,12 @@ msgstr "Qté conditionnement"
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
 msgid "Point of Sale"
 msgstr "Point de Vente"
+
+#. module: grap_change_views_product
+#: model:ir.model.fields,help:grap_change_views_product.field_product_product__list_price
+#: model:ir.model.fields,help:grap_change_views_product.field_product_template__list_price
+msgid "Price at which the product is sold to customers."
+msgstr "Prix auquel l'article est vendu aux clients."
 
 #. module: grap_change_views_product
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
@@ -477,3 +468,22 @@ msgstr "⇒ Baisser le prix"
 msgid "⇒ Increase Price"
 msgstr "⇒ Augmenter le prix"
 
+#. module: grap_change_views_product
+#: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
+msgid "✅ Notations"
+msgstr ""
+
+#. module: grap_change_views_product
+#: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
+msgid "🌱 Organic informations"
+msgstr "🌱 Informations bio"
+
+#. module: grap_change_views_product
+#: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
+msgid "🍴 Alimentary informations"
+msgstr "🍴 Informations alimentaire"
+
+#. module: grap_change_views_product
+#: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
+msgid "🚩 Production place"
+msgstr "🚩 Lieu de production"

--- a/grap_change_views_product/views/view_product_product_form.xml
+++ b/grap_change_views_product/views/view_product_product_form.xml
@@ -232,31 +232,38 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             </group>
                         </page>
                         <page string="Extra Informations">
-                            <group string="Origin" col="4">
-                                <field name="country_id"/>
-                                <field name="state_id"/>
-                                <field name="department_id"/>
-                                <field name="origin_description"/>
-                                <field name="maker_description"/>
-                            </group>
-                            <group string="Alimentary Information" col="4">
-                                <field name="is_alcohol" attrs="{'invisible': [('is_alimentary', '=', False)]}"/>
-                                <field name="best_before_date_day" attrs="{'invisible': [('is_alimentary', '=', False)]}"/>
-                                <field name="label_ids" widget="many2many_tags" colspan="4"/>
-                                <field name="is_uncertifiable" attrs="{'invisible': [('is_alimentary', '=', False)]}"/>
-                                <field name="organic_type"/>
-                            </group>
-                            <group>
-                                <group string="Notations">
-                                    <field name="local_notation"/>
-                                    <field name="social_notation"/>
-                                    <field name="packaging_notation"/>
-                                    <field name="organic_notation"/>
-                                </group>
                                 <group>
-                                    <field name="spider_chart_image" widget="image"
-                                        class="spider_chart"
-                                        nolabel="1" colspan="2"/>
+                                <group string="🚩 Production place">
+                                    <field name="maker_description"/>
+                                    <field name="department_id"/>
+                                    <field name="state_id"/>
+                                    <field name="country_id"/>
+                                    <field name="origin_description"/>
+                                </group>
+                                <group string="🌱 Organic informations">
+                                    <field name="country_group_id"/>
+                                    <field name="label_ids" widget="many2many_tags"/>
+                                    <field name="is_uncertifiable" attrs="{'invisible': [('is_alimentary', '=', False)]}"/>
+                                    <field name="organic_type"/>
+                                    <field name="pricetag_origin"/>
+                                </group>
+                                <group string="🍴 Alimentary informations">
+                                    <field name="is_vegan"/>
+                                    <field name="is_alcohol" attrs="{'invisible': [('is_alimentary', '=', False)]}"/>
+                                    <field name="best_before_date_day" attrs="{'invisible': [('is_alimentary', '=', False)]}"/>
+                                </group>
+                                <group string="✅ Notations">
+                                    <group>
+                                        <field name="local_notation"/>
+                                        <field name="social_notation"/>
+                                        <field name="packaging_notation"/>
+                                        <field name="organic_notation"/>
+                                    </group>
+                                    <group>
+                                        <field name="spider_chart_image" widget="image"
+                                            class="spider_chart"
+                                            nolabel="1" colspan="2"/>
+                                    </group>
                                 </group>
                             </group>
                         </page>

--- a/grap_qweb_report/report/qweb_pricetag_square_large.xml
+++ b/grap_qweb_report/report/qweb_pricetag_square_large.xml
@@ -31,13 +31,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                     <img class="product_label" t-attf-src="data:image/*;base64,{{label.image}}" t-att-alt="label.name"/>
                                 </t>
                             </div>
-                            <div class="non_ue">
-                                <t t-foreach="line.product_id.label_ids" t-as="label">
-                                    <t t-if="label.id == 36">
-                                        <span>Agriculture UE - NON UE</span>
-                                    </t>
-                                </t>
-                            </div>
                             <div class="organic_text">
                                 <t t-if="line.product_id.pricetag_organic_text">
                                     <t t-esc="line.product_id.pricetag_organic_text"/><br/>

--- a/grap_qweb_report/static/css/pricetag_square_large.scss
+++ b/grap_qweb_report/static/css/pricetag_square_large.scss
@@ -76,11 +76,6 @@
     img.product_label{
         width: 1.6cm; height: 1.6cm;
     }
-    .non_ue {
-        height: 0.6cm;
-        font-size: 12px;
-        padding-left: 15px;
-    }
     .product_labels, .organic_text{
         overflow: hidden;
     }

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -13,6 +13,7 @@ web
 
 account-financial-tools__account_subsequence_fiscal_year  https://github.com/legalsylvain/account-financial-tools.git   12.0-add-account_subsequence_fiscal_year
 
+a_grap-odoo-business__country_group      https://github.com/quentinDupont/grap-odoo-business.git      12.0_IMP_origin_country_group
 
 web__web_favorite_company      https://github.com/legalsylvain/web.git      12.0-ADD-web_favorite_company
 web__web_dashboard_tile      https://github.com/legalsylvain/web.git      12.0-mig-web_dashboard_tile


### PR DESCRIPTION
- Fiche produit
  - voir https://github.com/grap/grap-odoo-business/pull/80
- Modification groupe de pays
  - Europe → Union Européene
  - Enlève le champ traductible de res.country.group
  - Pas le droit de créer de nvo group (sauf pour les admins)

Travis pète pour nvo champ issu de cette PR : https://github.com/grap/grap-odoo-business/pull/80

![image](https://user-images.githubusercontent.com/9005817/122763985-438ed800-d29f-11eb-957b-96db866bc4e3.png)
