### PR TITLE
 [REM] remove default to False for uom_id / uom_po_id to allow correct onchange on product.product

### DIFF
--- a/grap_change_default/models/product_template.py
+++ b/grap_change_default/models/product_template.py
@@ -8,6 +8,4 @@ from odoo import fields, models
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    uom_id = fields.Many2one(default=False)
-    uom_po_id = fields.Many2one(default=False)
     categ_id = fields.Many2one(default=False)


### PR DESCRIPTION
apps/deck/#/board/144/card/1758

Dû à un vieux code tout pourri ici  (un ``onchange(x)`` qui fait un ``self.x = ...``), C'est bien naze.

https://github.com/odoo/odoo/blob/12.0/addons/product/models/product.py#L337