### PR TITLE
[IMP] Partner type easier choice

### DIFF
--- a/grap_change_views_base/__manifest__.py
+++ b/grap_change_views_base/__manifest__.py
@@ -20,7 +20,6 @@
         "views/view_ir_model_access.xml",
         "views/view_ir_sequence.xml",
         "views/view_res_company.xml",
-        "views/view_res_partner.xml",
         "views/view_ir_module_module.xml",
         "views/view_ir_actions_act_window.xml",
         "views/menu.xml",

--- a/grap_change_views_partner/__init__.py
+++ b/grap_change_views_partner/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/grap_change_views_partner/__manifest__.py
+++ b/grap_change_views_partner/__manifest__.py
@@ -3,18 +3,22 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "GRAP - Change Partner Views",
-    "version": "12.0.0.0.12",
+    "version": "12.0.0.0.13",
     "category": "GRAP - Custom",
     "author": "GRAP",
     "website": "http://www.grap.coop",
     "license": "AGPL-3",
     "depends": [
-        # Odoo Modules
         "account",
+        "base",
         "contacts",
+        "delivery",
+        "purchase",
         "product",
+        "stock",
     ],
     "data": [
+        "views/view_res_partner.xml",
         "views/view_res_partner_tree.xml",
     ],
     "installable": True,

--- a/grap_change_views_partner/i18n/fr.po
+++ b/grap_change_views_partner/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-28 10:23+0000\n"
-"PO-Revision-Date: 2021-07-28 10:23+0000\n"
+"POT-Creation-Date: 2021-07-29 12:07+0000\n"
+"PO-Revision-Date: 2021-07-29 12:07+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,12 +21,12 @@ msgid "Contact"
 msgstr ""
 
 #. module: grap_change_views_partner
-#: selection:res.partner,partner_type:0
+#: selection:res.partner,partner_type_selec:0
 msgid "Customer"
 msgstr "Client·e"
 
 #. module: grap_change_views_partner
-#: selection:res.partner,partner_type:0
+#: selection:res.partner,partner_type_selec:0
 msgid "Customer and supplier"
 msgstr "Client·e et fournisseur·se"
 
@@ -36,22 +36,17 @@ msgid "Inline editable"
 msgstr "Vue éditable en ligne"
 
 #. module: grap_change_views_partner
-#: selection:res.partner,partner_type:0
-msgid "Neither customer nore supplier"
-msgstr "Ni client·e ni fournisseur·se"
-
-#. module: grap_change_views_partner
 #: model:ir.actions.act_window,name:grap_change_views_partner.action_res_partner_editable_view
 msgid "Partner"
 msgstr "Contacts"
 
 #. module: grap_change_views_partner
-#: model:ir.model.fields,field_description:grap_change_views_partner.field_res_partner__partner_type
-#: model:ir.model.fields,field_description:grap_change_views_partner.field_res_users__partner_type
+#: model:ir.model.fields,field_description:grap_change_views_partner.field_res_partner__partner_type_selec
+#: model:ir.model.fields,field_description:grap_change_views_partner.field_res_users__partner_type_selec
 msgid "Partner type"
 msgstr "Type de contact"
 
 #. module: grap_change_views_partner
-#: selection:res.partner,partner_type:0
+#: selection:res.partner,partner_type_selec:0
 msgid "Supplier"
 msgstr "Fournisseur·se"

--- a/grap_change_views_partner/i18n/fr.po
+++ b/grap_change_views_partner/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-10-26 09:04+0000\n"
-"PO-Revision-Date: 2020-10-26 09:04+0000\n"
+"POT-Creation-Date: 2021-07-28 10:23+0000\n"
+"PO-Revision-Date: 2021-07-28 10:23+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,11 +16,42 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: grap_change_views_partner
+#: model:ir.model,name:grap_change_views_partner.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: grap_change_views_partner
+#: selection:res.partner,partner_type:0
+msgid "Customer"
+msgstr "Client·e"
+
+#. module: grap_change_views_partner
+#: selection:res.partner,partner_type:0
+msgid "Customer and supplier"
+msgstr "Client·e et fournisseur·se"
+
+#. module: grap_change_views_partner
 #: model:ir.ui.menu,name:grap_change_views_partner.menu_res_partner_editable_view
 msgid "Inline editable"
 msgstr "Vue éditable en ligne"
 
 #. module: grap_change_views_partner
+#: selection:res.partner,partner_type:0
+msgid "Neither customer nore supplier"
+msgstr "Ni client·e ni fournisseur·se"
+
+#. module: grap_change_views_partner
 #: model:ir.actions.act_window,name:grap_change_views_partner.action_res_partner_editable_view
 msgid "Partner"
 msgstr "Contacts"
+
+#. module: grap_change_views_partner
+#: model:ir.model.fields,field_description:grap_change_views_partner.field_res_partner__partner_type
+#: model:ir.model.fields,field_description:grap_change_views_partner.field_res_users__partner_type
+msgid "Partner type"
+msgstr "Type de contact"
+
+#. module: grap_change_views_partner
+#: selection:res.partner,partner_type:0
+msgid "Supplier"
+msgstr "Fournisseur·se"

--- a/grap_change_views_partner/migrations/12.0.0.0.13/pre-migration.py
+++ b/grap_change_views_partner/migrations/12.0.0.0.13/pre-migration.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+# @author: DUPONT Quentin (quentin.dupont@grap.coop)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+
+def migrate(cr, version):
+
+    # Add column
+    cr.execute(
+        """
+        ALTER TABLE res_partner ADD COLUMN partner_type_selec varchar;
+    """
+    )
+
+    # Populate
+    cr.execute(
+        """
+        UPDATE res_partner
+        SET partner_type_selec = 'customer'
+        WHERE res_partner.customer = true
+        AND res_partner.supplier = false;
+    """
+    )
+
+    cr.execute(
+        """
+        UPDATE res_partner
+        SET partner_type_selec = 'supplier'
+        WHERE res_partner.customer = false
+        AND res_partner.supplier = true;
+    """
+    )
+
+    cr.execute(
+        """
+        UPDATE res_partner
+        SET partner_type_selec = 'customer_supplier'
+        WHERE res_partner.customer = true
+        AND res_partner.supplier = true;
+    """
+    )
+
+    cr.execute(
+        """
+        UPDATE res_partner
+        SET partner_type_selec = 'none'
+        WHERE res_partner.customer = false
+        AND res_partner.supplier = false;
+    """
+    )

--- a/grap_change_views_partner/migrations/12.0.0.0.13/pre-migration.py
+++ b/grap_change_views_partner/migrations/12.0.0.0.13/pre-migration.py
@@ -26,7 +26,7 @@ def migrate(cr, version):
         """
         UPDATE res_partner
         SET partner_type_selec = 'supplier'
-        WHERE res_partner.customer = false
+        WHERE res_partner.customer = false OR res_partner.customer = null
         AND res_partner.supplier = true;
     """
     )
@@ -35,7 +35,7 @@ def migrate(cr, version):
         """
         UPDATE res_partner
         SET partner_type_selec = 'customer_supplier'
-        WHERE res_partner.customer = true
+        WHERE res_partner.customer = true OR res_partner.customer = null
         AND res_partner.supplier = true;
     """
     )
@@ -43,8 +43,8 @@ def migrate(cr, version):
     cr.execute(
         """
         UPDATE res_partner
-        SET partner_type_selec = 'none'
-        WHERE res_partner.customer = false
+        SET partner_type_selec = 'customer_supplier'
+        WHERE res_partner.customer = false OR res_partner.customer = null
         AND res_partner.supplier = false;
     """
     )

--- a/grap_change_views_partner/models/__init__.py
+++ b/grap_change_views_partner/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner

--- a/grap_change_views_partner/models/res_partner.py
+++ b/grap_change_views_partner/models/res_partner.py
@@ -9,7 +9,6 @@ class ResPartner(models.Model):
     _inherit = "res.partner"
 
     _PARTNER_TYPE_SELECTION = [
-        ("none", "Neither customer nore supplier"),
         ("customer", "Customer"),
         ("supplier", "Supplier"),
         ("customer_supplier", "Customer and supplier"),
@@ -19,13 +18,11 @@ class ResPartner(models.Model):
         string="Partner type",
         selection=_PARTNER_TYPE_SELECTION,
         required=True,
-        default="customer_supplier",
     )
 
     # Compute Section
     @api.onchange("partner_type_selec")
     def onchange_supplier_customer(self):
-        # import pdb; pdb.set_trace()
         for partner in self:
             if partner.partner_type_selec == "customer":
                 partner.customer = True
@@ -36,6 +33,3 @@ class ResPartner(models.Model):
             elif partner.partner_type_selec == "customer_supplier":
                 partner.customer = True
                 partner.supplier = True
-            else:
-                partner.customer = False
-                partner.supplier = False

--- a/grap_change_views_partner/models/res_partner.py
+++ b/grap_change_views_partner/models/res_partner.py
@@ -1,0 +1,41 @@
+# Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+# @author: Quentin DUPONT (quentin.dupont@grap.coop)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, fields, models
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    _PARTNER_TYPE_SELECTION = [
+        ("none", "Neither customer nore supplier"),
+        ("customer", "Customer"),
+        ("supplier", "Supplier"),
+        ("customer_supplier", "Customer and supplier"),
+    ]
+
+    partner_type_selec = fields.Selection(
+        string="Partner type",
+        selection=_PARTNER_TYPE_SELECTION,
+        required=True,
+        default="customer_supplier",
+    )
+
+    # Compute Section
+    @api.onchange("partner_type_selec")
+    def onchange_supplier_customer(self):
+        # import pdb; pdb.set_trace()
+        for partner in self:
+            if partner.partner_type_selec == "customer":
+                partner.customer = True
+                partner.supplier = False
+            elif partner.partner_type_selec == "supplier":
+                partner.customer = False
+                partner.supplier = True
+            elif partner.partner_type_selec == "customer_supplier":
+                partner.customer = True
+                partner.supplier = True
+            else:
+                partner.customer = False
+                partner.supplier = False

--- a/grap_change_views_partner/views/view_res_partner.xml
+++ b/grap_change_views_partner/views/view_res_partner.xml
@@ -22,7 +22,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 <attribute name="groups">base.group_erp_manager</attribute>
             </field>
             <field name="type" position="before">
-                <field name="partner_type"/>
+                <field name="partner_type_selec"/>
             </field>
             <xpath expr="//group[@name='sale']/field[@name='customer']" position="attributes">
                 <attribute name="attrs">{'readonly': 1}</attribute>

--- a/grap_change_views_partner/views/view_res_partner.xml
+++ b/grap_change_views_partner/views/view_res_partner.xml
@@ -21,6 +21,15 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="title" position="attributes">
                 <attribute name="groups">base.group_erp_manager</attribute>
             </field>
+            <field name="type" position="before">
+                <field name="partner_type"/>
+            </field>
+            <xpath expr="//group[@name='sale']/field[@name='customer']" position="attributes">
+                <attribute name="attrs">{'readonly': 1}</attribute>
+            </xpath>
+            <xpath expr="//group[@name='purchase']/field[@name='supplier']" position="attributes">
+                <attribute name="attrs">{'readonly': 1}</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
![Peek 28-07-2021 12-31](https://user-images.githubusercontent.com/9005817/127308655-35f20672-d7cf-4e85-85f2-17062422b992.gif)

- Champ appelé `partner_type_selec` car `partner_type` existait déjà dans d'autres contextes, donc je voulais éviter des confusions
- J'ai déplace l'héritage de partner_view dans le dossier adéquate aussi
- Je rends readonly les champs `Est un client` et `Est un fournisseur`
- Script migration fait :blush: 
- Pas de valeur par défaut mais champ obligatoire
 
Deck : apps/deck/#/board/144/card/1355