### PR TITLE
[FIX] grap_qweb_report : display correct RIB on main GRAP layout. 

### DIFF
--- a/grap_qweb_report/report/qweb_template_layout_standard.xml
+++ b/grap_qweb_report/report/qweb_template_layout_standard.xml
@@ -142,12 +142,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                     <span>Pas d'escompte pour paiement anticipé. Pénalité de retard : 3 fois le taux d'intérêt légal. Montant forfaitaire pour frais de recouvrement dû au créancier en cas de retard de paiement : 40€</span>
                                     <br/><span>Règlement par chèque à l'ordre de <b><span t-esc="company.fiscal_company_id.name.replace('|','')"/></b>. </span>
                                 </span>
-                                <span t-if="len(company.bank_ids)">
-                                    <span t-if="o._name in ('sale.order', 'account.invoice')">Règlement par virement sur le compte <span t-esc="company.bank_ids[0].bank_name"/>.</span>
+                                <span t-if="len(company.partner_id.bank_ids)">
+                                    <span t-if="o._name in ('sale.order', 'account.invoice')">Règlement par virement sur le compte <span t-esc="company.partner_id.bank_ids[0].bank_name"/>.</span>
                                     <span>
                                         <br/>
-                                        <b>IBAN : </b><span t-esc="company.bank_ids[0].acc_number"/>
-                                        <b> - SWIFT/BIC : </b><span t-esc="company.bank_ids[0].bank_bic"/>
+                                        <b>IBAN : </b><span t-esc="company.partner_id.bank_ids[0].acc_number"/>
+                                        <b> - SWIFT/BIC : </b><span t-esc="company.partner_id.bank_ids[0].bank_bic"/>
                                     </span>
                                 </span>
                             </div>


### PR DESCRIPTION
Fix bug introduced in #183, (merged the 23/06/2021)


Deck : apps/deck/#/board/144/card/1851