### PR TITLE
[FIX] mrp_food : set compute_sudo to is_component field

### DIFF
--- a/mrp_food/models/product_product.py
+++ b/mrp_food/models/product_product.py
@@ -34,6 +34,7 @@ class ProductProduct(models.Model):
 
     is_component = fields.Boolean(
         compute="_compute_is_component",
+        compute_sudo=True,
         store=True,
         default=False,
     )

--- a/mrp_food/models/product_product.py
+++ b/mrp_food/models/product_product.py
@@ -31,7 +31,8 @@ class ProductProduct(models.Model):
         compute="_compute_is_seasonal",
         default=False,
     )
-
+    # because the computation is based on mrp.bom.line,
+    # that is not available for user that doesn't belong to mrp user group
     is_component = fields.Boolean(
         compute="_compute_is_component",
         compute_sudo=True,


### PR DESCRIPTION
 because the computation is based on mrp.bom.line, that is not available for user that doesn't belong to mrp user group
