### PR TITLE
[FIX] MRP access rights, user can be Manufacturing User now

### DIFF
--- a/grap_change_access/security/ir.model.access.csv
+++ b/grap_change_access/security/ir.model.access.csv
@@ -18,3 +18,5 @@ sale_order_template manager,sale_order_template manager,sale_management.model_sa
 sale_order_template_line manager,sale_order_template_line manager,sale_management.model_sale_order_template_line,sales_team.group_sale_salesman_all_leads,1,1,1,1
 sale_order_template_option manager,sale_order_template_option manager,sale_management.model_sale_order_template_option,sales_team.group_sale_salesman_all_leads,1,1,1,1
 sale_order user,sale_order user,sale.model_sale_order,sales_team.group_sale_salesman,1,1,1,1
+access_mrp_bom_user,Grap MRP User,mrp.model_mrp_bom,mrp.group_mrp_user,1,1,1,1
+access_mrp_bom_line_user,Grap MRP User,mrp.model_mrp_bom_line,mrp.group_mrp_user,1,1,1,1

--- a/mrp_food/security/ir.model.access.csv
+++ b/mrp_food/security/ir.model.access.csv
@@ -1,5 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_seasonality_manager,Seasonality Manager,model_seasonality,mrp.group_mrp_manager,1,1,1,1
+access_seasonality_manager,Seasonality Manager,model_seasonality,mrp.group_mrp_user,1,1,1,1
 access_seasonality_all,Seasonality All,model_seasonality,,1,,,
-access_seasonality_line_manager,Seasonality Line Manager,model_seasonality_line,mrp.group_mrp_manager,1,1,1,1
+access_seasonality_line_manager,Seasonality Line Manager,model_seasonality_line,mrp.group_mrp_user,1,1,1,1
 access_seasonality_line_all,Seasonality Line All,model_seasonality_line,,1,,,


### PR DESCRIPTION
[Odoo Project task 663](https://erp.grap.coop/web#id=663&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673)

Goal : user can be set as Manufacturing / User and not Manufacturing / Manager

So we add rights for Bom and Bom lines and Seasonality
That remove rights for Product Category, UoM etc.