### PR TITLE
[FIX] Glue module for main seller and invoice update price

### DIFF
--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/__init__.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/__init__.py
@@ -1,0 +1,2 @@
+from . import models
+from . import wizard

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/__manifest__.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/__manifest__.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2022 - Today: GRAP (http://www.grap.coop)
+# @author: Quentin Dupont (quentin.dupont@grap.coop)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Account Invoice Supplierinfo Update Standard Price Main Seller",
+    "version": "12.0.1.0.1",
+    "category": "GRAP Custom",
+    "author": "GRAP",
+    "website": "https://github.com/grap/grap-odoo-custom",
+    "license": "AGPL-3",
+    "depends": [
+        # GRAP
+        "account_invoice_supplierinfo_update_standard_price",
+        "product_main_seller",
+    ],
+    "data": [
+        "wizard/wizard_update_invoice_supplierinfo.xml",
+    ],
+    "auto_install": True,
+    "installable": True,
+}

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/i18n/fr.po
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/i18n/fr.po
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_invoice_supplierinfo_update_standard_price_product_main_seller
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 12.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-12-21 11:07+0000\n"
+"PO-Revision-Date: 2022-12-21 11:07+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: account_invoice_supplierinfo_update_standard_price_product_main_seller
+#: model:ir.model,name:account_invoice_supplierinfo_update_standard_price_product_main_seller.model_account_invoice_line
+msgid "Invoice Line"
+msgstr "Ligne de facture"
+
+#. module: account_invoice_supplierinfo_update_standard_price_product_main_seller
+#: model:ir.model.fields,field_description:account_invoice_supplierinfo_update_standard_price_product_main_seller.field_wizard_update_invoice_supplierinfo_line__is_line_main_seller_price
+msgid "Main seller"
+msgstr "Frs. principal"
+
+#. module: account_invoice_supplierinfo_update_standard_price_product_main_seller
+#: model:ir.model,name:account_invoice_supplierinfo_update_standard_price_product_main_seller.model_wizard_update_invoice_supplierinfo_line
+msgid "Wizard Line to update supplierinfo"
+msgstr "Line d'assistant pour mettre à jour les informations fournisseurs"
+
+#. module: account_invoice_supplierinfo_update_standard_price_product_main_seller
+#: model:ir.model,name:account_invoice_supplierinfo_update_standard_price_product_main_seller.model_wizard_update_invoice_supplierinfo
+msgid "Wizard to update supplierinfo"
+msgstr "Assistant de mise à jour des informations fournisseurs"

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/i18n/fr.po
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-21 11:07+0000\n"
-"PO-Revision-Date: 2022-12-21 11:07+0000\n"
+"POT-Creation-Date: 2023-02-01 11:54+0000\n"
+"PO-Revision-Date: 2023-02-01 11:54+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -22,6 +22,7 @@ msgstr "Ligne de facture"
 
 #. module: account_invoice_supplierinfo_update_standard_price_product_main_seller
 #: model:ir.model.fields,field_description:account_invoice_supplierinfo_update_standard_price_product_main_seller.field_wizard_update_invoice_supplierinfo_line__is_line_main_seller_price
+#: model:ir.model.fields,field_description:account_invoice_supplierinfo_update_standard_price_product_main_seller.field_wizard_update_invoice_supplierinfo_line__is_line_main_seller_price_icon
 msgid "Main seller"
 msgstr "Frs. principal"
 
@@ -29,8 +30,3 @@ msgstr "Frs. principal"
 #: model:ir.model,name:account_invoice_supplierinfo_update_standard_price_product_main_seller.model_wizard_update_invoice_supplierinfo_line
 msgid "Wizard Line to update supplierinfo"
 msgstr "Line d'assistant pour mettre à jour les informations fournisseurs"
-
-#. module: account_invoice_supplierinfo_update_standard_price_product_main_seller
-#: model:ir.model,name:account_invoice_supplierinfo_update_standard_price_product_main_seller.model_wizard_update_invoice_supplierinfo
-msgid "Wizard to update supplierinfo"
-msgstr "Assistant de mise à jour des informations fournisseurs"

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/models/__init__.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice_line

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/models/account_invoice_line.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2022 - Today: GRAP (http://www.grap.coop)
+# @author: Quentin DUPONT (quentin.dupont@grap.coop)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = "account.invoice.line"
+
+    @api.multi
+    def _prepare_supplier_wizard_line(self, supplierinfo):
+        self.ensure_one()
+        res = super()._prepare_supplier_wizard_line(supplierinfo)
+        res["is_line_main_seller_price"] = (
+            supplierinfo and supplierinfo.is_main_seller or False
+        )
+        return res

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/models/account_invoice_line.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/models/account_invoice_line.py
@@ -15,4 +15,8 @@ class AccountInvoiceLine(models.Model):
         res["is_line_main_seller_price"] = (
             supplierinfo and supplierinfo.is_main_seller or False
         )
+        if supplierinfo and supplierinfo.is_main_seller:
+            res["is_line_main_seller_price_icon"] = "🥇"
+        else:
+            res["is_line_main_seller_price_icon"] = "✖️"
         return res

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/readme/CONTRIBUTORS.rst
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Quentin DUPONT (quentin.dupont@grap.coop)

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/readme/DESCRIPTION.rst
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/readme/DESCRIPTION.rst
@@ -1,0 +1,3 @@
+This module is a glue module between "Account Invoice - Standard Price Update"
+and "Product Main Seller" module to correctly set main seller for product while
+using wizard to update standard price.

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/__init__.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/__init__.py
@@ -1,0 +1,1 @@
+from . import wizard_update_invoice_supplierinfo_line

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo.xml
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2022 - Today: GRAP (http://www.grap.coop)
+@author: Quentin DUPONT (quentin.dupont@grap.coop)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="view_wizard_account_invoice_supplierinfo_update_standar_price_form" model="ir.ui.view">
+        <field name="model">wizard.update.invoice.supplierinfo</field>
+        <field name="inherit_id" ref="account_invoice_supplierinfo_update_standard_price.view_wizard_update_invoice_supplierinfo_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='line_ids']/tree/field[@name='new_standard_price']" position="after">
+                <field name="is_line_main_seller_price"/>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo.xml
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo.xml
@@ -11,7 +11,8 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="inherit_id" ref="account_invoice_supplierinfo_update_standard_price.view_wizard_update_invoice_supplierinfo_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='line_ids']/tree/field[@name='new_standard_price']" position="after">
-                <field name="is_line_main_seller_price"/>
+                <field name="is_line_main_seller_price" invisible="1"/>
+                <field name="is_line_main_seller_price_icon" readonly="1"/>
             </xpath>
         </field>
     </record>

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo_line.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo_line.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2022 - Today: GRAP (http://www.grap.coop)
+# @author: Quentin DUPONT (quentin.dupont@grap.coop)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import fields, models
+
+
+class WizardUpdateInvoiceSupplierinfoLine(models.TransientModel):
+    _inherit = "wizard.update.invoice.supplierinfo.line"
+
+    is_line_main_seller_price = fields.Boolean(
+        string="Main seller",
+        readonly=True,
+    )

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo_line.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo_line.py
@@ -12,3 +12,10 @@ class WizardUpdateInvoiceSupplierinfoLine(models.TransientModel):
         string="Main seller",
         readonly=True,
     )
+
+    def _prepare_supplierinfo_update(self):
+        res = super()._prepare_supplierinfo_update()
+        # Arbitrarily we set a big sequence for this supplier info
+        # not to be in sequence=1 and be falsely main seller
+        res["sequence"] = 100
+        return res

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo_line.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo_line.py
@@ -12,6 +12,7 @@ class WizardUpdateInvoiceSupplierinfoLine(models.TransientModel):
         string="Main seller",
         readonly=True,
     )
+    is_line_main_seller_price_icon = fields.Char(string="Main seller", default="🥇")
 
     def _prepare_supplierinfo_update(self):
         res = super()._prepare_supplierinfo_update()

--- a/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo_line.py
+++ b/account_invoice_supplierinfo_update_standard_price_product_main_seller/wizard/wizard_update_invoice_supplierinfo_line.py
@@ -16,7 +16,9 @@ class WizardUpdateInvoiceSupplierinfoLine(models.TransientModel):
 
     def _prepare_supplierinfo_update(self):
         res = super()._prepare_supplierinfo_update()
-        # Arbitrarily we set a big sequence for this supplier info
-        # not to be in sequence=1 and be falsely main seller
-        res["sequence"] = 100
+        if not self.is_line_main_seller_price:
+            # By default, when we add a supplierinfo, it sets sequence=1
+            # Arbitrarily we set a big sequence for supplier info that are not
+            # main seller
+            res["sequence"] = 100
         return res

--- a/product_main_seller/models/product_product.py
+++ b/product_main_seller/models/product_product.py
@@ -25,5 +25,5 @@ class ProductProduct(models.Model):
     @api.depends("variant_seller_ids.sequence")
     def _compute_main_seller_partner_id(self):
         for prod in self:
-            if len(prod.variant_seller_ids) > 0:
+            if len(prod.variant_seller_ids):
                 prod.product_main_seller_partner_id = prod.variant_seller_ids[0].name

--- a/product_main_seller/models/product_product.py
+++ b/product_main_seller/models/product_product.py
@@ -25,5 +25,5 @@ class ProductProduct(models.Model):
     @api.depends("variant_seller_ids.sequence")
     def _compute_main_seller_partner_id(self):
         for prod in self:
-            if len(prod.variant_seller_ids):
+            if len(prod.variant_seller_ids) > 0:
                 prod.product_main_seller_partner_id = prod.variant_seller_ids[0].name

--- a/product_supplierinfo_standard_price/models/product_supplierinfo.py
+++ b/product_supplierinfo_standard_price/models/product_supplierinfo.py
@@ -106,7 +106,3 @@ class SupplierInfo(models.Model):
                     _("New standard price for %s") % supplierinfo.product_tmpl_id.name
                 ),
             )
-            # Set supplierinfo first seller for this product
-            for _suppinfo in supplierinfo.product_tmpl_id.variant_seller_ids:
-                _suppinfo.sequence = _suppinfo.sequence + 1
-            supplierinfo.sequence = 1

--- a/setup/account_invoice_supplierinfo_update_standard_price_product_main_seller/odoo/addons/account_invoice_supplierinfo_update_standard_price_product_main_seller
+++ b/setup/account_invoice_supplierinfo_update_standard_price_product_main_seller/odoo/addons/account_invoice_supplierinfo_update_standard_price_product_main_seller
@@ -1,0 +1,1 @@
+../../../../account_invoice_supplierinfo_update_standard_price_product_main_seller

--- a/setup/account_invoice_supplierinfo_update_standard_price_product_main_seller/setup.py
+++ b/setup/account_invoice_supplierinfo_update_standard_price_product_main_seller/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Odoo task 720 : https://erp.grap.coop/web#id=720&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673

- "Use this price" action doesn't set supplier_info as main seller anymore
- Wizard in account invoice : 
  - Display Main Seller in Wizard for Updating Prices in Account Invoice 
  - avoid to set sequence 1 and make supplier info main seller