### PR TITLE
[FIX] grap_change_views_pos : hide field on pos.config kanban view be…

### DIFF
--- a/grap_change_views_pos/views/view_pos_config.xml
+++ b/grap_change_views_pos/views/view_pos_config.xml
@@ -20,4 +20,14 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
+    <record id="view_pos_config_kanban" model="ir.ui.view">
+        <field name="model">pos.config</field>
+        <field name="inherit_id" ref="point_of_sale.view_pos_config_kanban" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@t-if='record.last_session_closing_date.value'][2]" position="attributes">
+                <attribute name="attrs">{'invisible': 1}</attribute>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
…cause the translation 'Solde de trésorerie' doesn't mean nothin

[Tâche](https://erp.grap.coop/web#id=428&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673).