### PR TITLE
[IMP] grap_qweb_report :

### DIFF
--- a/grap_qweb_report/__manifest__.py
+++ b/grap_qweb_report/__manifest__.py
@@ -54,5 +54,6 @@
     "qweb": [
         "static/src/xml/pos.xml",
     ],
+    "external_dependencies": {"python": ["slugify"]},
     "installable": True,
 }

--- a/grap_qweb_report/__manifest__.py
+++ b/grap_qweb_report/__manifest__.py
@@ -5,7 +5,7 @@
 
 {
     "name": "GRAP - Custom Qweb Reports",
-    "version": "12.0.1.2.6",
+    "version": "12.0.2.0.1",
     "category": "GRAP - Custom",
     "author": "GRAP",
     "website": "https://github.com/grap/grap-odoo-custom",

--- a/grap_qweb_report/data/ir_actions_report_xml.xml
+++ b/grap_qweb_report/data/ir_actions_report_xml.xml
@@ -15,12 +15,17 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
+    <!--
+        - Use the same name for the saved file as for the downloaded file
+        - Do not store files for supplier invoices (and refund)
+    -->
     <record id="account.account_invoices" model="ir.actions.report">
-        <field name="print_report_name">
-            "Facture__%s__%s" % (
-                object.partner_id.name.replace("'","_").replace('"','').replace('/', '_'),
-                object.date_invoice if object.date_invoice else ""
-            )
+        <field name="attachment">(object.state in ('open','in_payment','paid') and object.type in ('out_invoice', 'out_refund')) and (object._get_report_base_filename())
+        </field>
+    </record>
+
+    <record id="account.account_invoices_without_payment" model="ir.actions.report">
+        <field name="attachment">(object.state in ('open','in_payment','paid') and object.type in ('out_invoice', 'out_refund')) and (object._get_report_base_filename())
         </field>
     </record>
 

--- a/grap_qweb_report/migrations/12.0.2.0.1/post-migration.py
+++ b/grap_qweb_report/migrations/12.0.2.0.1/post-migration.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Druidoo - Iván Todorovich
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.cr.execute(
+        """
+        SELECT id, name
+        FROM res_company
+        ORDER BY id;"""
+    )
+    company_datas = env.cr.fetchall()
+    for (company_id, company_name) in company_datas:
+        env.cr.execute(
+            """
+            SELECT ia.id
+            FROM ir_attachment ia
+            INNER JOIN account_invoice ai
+                ON ia.res_id = ai.id
+                AND ia.res_model = 'account.invoice'
+            WHERE ai.type in ('in_invoice', 'in_refund')
+            AND ai.company_id = %s""",
+            (company_id,),
+        )
+        attachment_datas = env.cr.fetchall()
+        if attachment_datas:
+            _logger.info(
+                "Unlinking %d attachments for supplier invoices for the company %d - %s"
+                % (len(attachment_datas), company_id, company_name)
+            )
+            attachment_ids = [x[0] for x in attachment_datas]
+            attachments = env["ir.attachment"].browse(attachment_ids)
+            attachments.with_context(intercompany_trade_create=True).unlink()

--- a/grap_qweb_report/models/account_invoice.py
+++ b/grap_qweb_report/models/account_invoice.py
@@ -2,9 +2,21 @@
 # @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from slugify import slugify
+
+from odoo import _, models
 
 
 class AccountInvoice(models.Model):
     _name = "account.invoice"
     _inherit = ["account.invoice", "report.custom.message.mixin"]
+
+    def _get_report_base_filename(self):
+        self.ensure_one()
+        return _("Invoice__{number}__{partner}__{date}").format(
+            number=slugify(self.number, lowercase=False)
+            or (self.state == "draft" and _("Draft"))
+            or "",
+            partner=self.partner_id and slugify(self.partner_id.name) or _("Anonymous"),
+            date=self.date_invoice and slugify(str(self.date_invoice)) or "",
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # generated from manifests external_dependencies
 openupgradelib
+python-slugify

--- a/setup/grap_qweb_report/setup.py
+++ b/setup/grap_qweb_report/setup.py
@@ -2,5 +2,11 @@ import setuptools
 
 setuptools.setup(
     setup_requires=['setuptools-odoo'],
-    odoo_addon=True,
+    odoo_addon={
+        "external_dependencies_override": {
+            "python": {
+                "slugify": "python-slugify"
+            }
+        }
+    },
 )


### PR DESCRIPTION
- use the same name for the attachement file and the downloaded file;
- do not overload the print_report_name as '_get_report_base_filename' is implemented for account.invoice;
- improve clean name, using slugify library;
- Do not store in invoices. (supplier invoices and supplier refund);