### PR TITLE
[IMP] Simplify_main_seller

### DIFF
--- a/grap_change_views_product/i18n/fr.po
+++ b/grap_change_views_product/i18n/fr.po
@@ -264,12 +264,12 @@ msgstr "PdV"
 #. module: grap_change_views_product
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_tree_price
 msgid "Main Seller"
-msgstr "Fourni. principal·e"
+msgstr "Frs principal·e"
 
 #. module: grap_change_views_product
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_tree
 msgid "Main seller"
-msgstr "Fourni. principal·e"
+msgstr "Frs principal·e"
 
 #. module: grap_change_views_product
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
@@ -589,7 +589,7 @@ msgstr "Liste de prix du fournisseur·e"
 #. module: grap_change_views_product
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
 msgid "Supplier product name"
-msgstr "Nom chez le fournisseur·e"
+msgstr "Nom chez frs."
 
 #. module: grap_change_views_product
 #: model:ir.ui.menu,name:grap_change_views_product.menu_grap_mrp_handle_prices_1b_supplierinfos
@@ -599,7 +599,7 @@ msgstr "Prix fournisseur·es"
 #. module: grap_change_views_product
 #: model:ir.actions.act_window,name:grap_change_views_product.action_product_supplierinfo_tree
 msgid "Suppliers informations"
-msgstr "Prix fournisseur·e·s"
+msgstr "Prix fournisseur·es"
 
 #. module: grap_change_views_product
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_supplierinfo_tree
@@ -667,6 +667,7 @@ msgid "Unit of measure"
 msgstr "Unité de mesure"
 
 #. module: grap_change_views_product
+#: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_form
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_product_tree
 #: model_terms:ir.ui.view,arch_db:grap_change_views_product.view_product_supplierinfo_tree
 msgid "UoM"

--- a/grap_change_views_product/views/view_product_product_form.xml
+++ b/grap_change_views_product/views/view_product_product_form.xml
@@ -115,8 +115,8 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                     <field name="uom_id"/>
                                     <field name="default_code" attrs="{'readonly': [('company_id', '!=', False)]}"/>
                                     <field name="tla_to_change" invisible="1"/>
-                                    <label for="tla" groups="mrp.group_mrp_manager"/>
-                                    <div groups="mrp.group_mrp_manager">
+                                    <label for="tla" groups="mrp.group_mrp_user"/>
+                                    <div groups="mrp.group_mrp_user">
                                       <field name="tla" class="oe_inline"/>
                                       <button name="generate_tla" string="⇒ Generate new trigram"
                                               type="object" class="oe_link" attrs="{'invisible': [('tla_to_change', '!=', True)]}"
@@ -152,9 +152,10 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                             attrs="{'readonly':[('is_consignment', '=', True)]}"
                                             groups="recurring_consignment.group_consignment_user"/>
                                     <field name="is_consignment" groups="recurring_consignment.group_consignment_manager"/>
-                                    <field name="standard_price" string="Cost Price (VAT Excl.)" widget="monetary" options="{'display_currency': 'currency_id'}"/>
+                                    <field name="standard_price" string="Cost Price (VAT Excl.)" widget="monetary" options="{'display_currency': 'currency_id', 'field_digits': True}"/>
                                     <field name="standard_price_tax_included" string="Cost Price (VAT Incl.)"
-                                        groups="base.group_erp_manager" widget="monetary" options="{'display_currency': 'currency_id'}"/>
+                                        groups="base.group_erp_manager" widget="monetary" options="{'display_currency': 'currency_id', 'field_digits': True}"/>
+                                    <field name="product_main_seller_partner_id"/>
                                     <field name="fiscal_classification_id" quick_create="false" required="1"/>
                                 </group>
                                 <group string="Sale">
@@ -216,9 +217,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                     <field name="seller_ids" nolabel="1">
                                         <tree editable="bottom" decoration-info="diff_supplierinfo_product_standard_price != 0">
                                             <field name="sequence" widget="handle"/>
-                                            <field name="currency_id" invisible="1"/>
-                                            <field name="is_main_seller" invisible="1"/>
-                                            <field class="is_main_seller_icon" name="is_main_seller_icon" string=" " readonly="1" attrs="{'invisible': [('is_main_seller', '=', False)]}"/>
                                             <field name="name"/>
                                             <field name="product_name" string="Supplier product name"
                                                 attrs="{'readonly': [('is_intercompany_trade', '=', True)]}"/>
@@ -226,11 +224,12 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                                 attrs="{'readonly': [('is_intercompany_trade', '=', True)]}"/>
                                             <field name="package_qty" string="Package Qty"/>
                                             <field name="min_qty" string="Min Qty"/>
-                                            <field name="price" widget="monetary" options="{'display_currency': 'currency_id'}"/>
+                                            <field name="price" widget="monetary" options="{'field_digits': True}"/>
+                                            <field name="product_uom" string="UoM"/>
                                             <field name="discount" string="Disc. 1 %"/>
                                             <field name="discount2"  string="Disc. 2 %"/>
                                             <field name="discount3" invisible="1"/>
-                                            <field name="theoritical_standard_price" string="Standard Price" widget="monetary" options="{'display_currency': 'currency_id'}"/>
+                                            <field name="theoritical_standard_price" string="Standard Price" widget="monetary" options="{'field_digits': 'True'}"/>
                                             <field name="diff_supplierinfo_product_standard_price" string="Diff" invisible="1"/>
                                             <button name="set_product_standard_price_from_supplierinfo" help="Use this price for product standard price" string="Use this price 🎯" class="btn_price_from_supplierinfo" type="object" attrs="{'invisible': [('diff_supplierinfo_product_standard_price', '=', 0)]}"/>
                                             <field name="is_intercompany_trade" invisible="1"/>

--- a/grap_change_views_product/views/view_product_supplierinfo.xml
+++ b/grap_change_views_product/views/view_product_supplierinfo.xml
@@ -41,8 +41,6 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="arch" type="xml">
           <tree editable="bottom" create="false" decoration-info="diff_supplierinfo_product_standard_price != 0">
             <field name="currency_id" invisible="1"/>
-            <field name="is_main_seller" invisible="1"/>
-            <field name="is_main_seller_icon" string=" " attrs="{'invisible': [('is_main_seller', '=', False)]}"/>
             <button name="see_current_product_from_supplierinfo" type="object" string="↗️"/>
             <field name="product_tmpl_code" string="Code"/>
             <field name="product_tmpl_name" string="Product"/>

--- a/mrp_food/static/src/scss/mrp_food.scss
+++ b/mrp_food/static/src/scss/mrp_food.scss
@@ -4,10 +4,6 @@
   margin-bottom: -10px;
 }
 
-.is_main_seller_icon{
-  font-size: 15px;
-}
-
 .btn_price_from_supplierinfo{
   height: 25px;
   line-height: 5px;

--- a/product_main_seller/i18n/fr.po
+++ b/product_main_seller/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-03 21:18+0000\n"
-"PO-Revision-Date: 2022-11-03 21:18+0000\n"
+"POT-Creation-Date: 2023-02-17 10:29+0000\n"
+"PO-Revision-Date: 2023-02-17 10:29+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -29,16 +29,6 @@ msgid "Deprecated"
 msgstr ""
 
 #. module: product_main_seller
-#: model:ir.model.fields,field_description:product_main_seller.field_product_supplierinfo__is_main_seller
-msgid "Is Main Seller"
-msgstr "Fournisseur·e principal·e"
-
-#. module: product_main_seller
-#: model:ir.model.fields,field_description:product_main_seller.field_product_supplierinfo__is_main_seller_icon
-msgid "Is Main Seller Icon"
-msgstr ""
-
-#. module: product_main_seller
 #: model:ir.model.fields,field_description:product_main_seller.field_product_product__product_main_seller_partner_id
 msgid "Main Product Seller Partner"
 msgstr "Fournisseur·e principal·e"
@@ -48,11 +38,6 @@ msgstr "Fournisseur·e principal·e"
 #: model:ir.model.fields,field_description:product_main_seller.field_product_template__main_seller_partner_id
 msgid "Main Seller Partner"
 msgstr "Fournisseur·e principal·e"
-
-#. module: product_main_seller
-#: model:ir.model.fields,help:product_main_seller.field_product_product__product_main_seller_partner_id
-msgid "Main Seller Partner of the product"
-msgstr "Fournisseur·e principal·e du produit"
 
 #. module: product_main_seller
 #: model:ir.model.fields,field_description:product_main_seller.field_product_product__main_seller_variant_partner_id
@@ -74,6 +59,11 @@ msgstr "Article"
 #: model:ir.model,name:product_main_seller.model_product_template
 msgid "Product Template"
 msgstr "Modèle d'article"
+
+#. module: product_main_seller
+#: model:ir.model.fields,help:product_main_seller.field_product_product__product_main_seller_partner_id
+msgid "Put your supplier info in first position to set as main supplier"
+msgstr "Mettez la ligne d'information fournisseur·e en première position pour le définir comme fournisseur·e principal·e."
 
 #. module: product_main_seller
 #: model:ir.model,name:product_main_seller.model_product_supplierinfo

--- a/product_main_seller/models/product_product.py
+++ b/product_main_seller/models/product_product.py
@@ -11,7 +11,7 @@ class ProductProduct(models.Model):
     product_main_seller_partner_id = fields.Many2one(
         comodel_name="res.partner",
         string="Main Product Seller Partner",
-        help="Main Seller Partner of the product",
+        help="Put your supplier info in first position to set as main supplier",
         compute="_compute_main_seller_partner_id",
         store=True,
     )


### PR DESCRIPTION
Remove conflict of #296 from @quentinDupont 

This PR  #302 is the same as the PR #296 except the change in [product_main_seller/models/product_supplierinfo.py](https://github.com/grap/grap-odoo-custom/pull/296/files#diff-8c86728848a043d63cf16f6742dfc85aa30c29a5d673a15cb5d1a8abfd430e81) that is introduced by this commit https://github.com/grap/grap-odoo-custom/pull/296/commits/44b6287848bbce9443cd49a70069165e6b957452 but come from another PR #281 : https://github.com/grap/grap-odoo-custom/pull/281/files#diff-8c86728848a043d63cf16f6742dfc85aa30c29a5d673a15cb5d1a8abfd430e81

Detail commit : 
- getting code from PR 280
- Add field on Grap change views product
- get PR 280 : uom on supplier