### PR TITLE
[FIx] grap_qweb_report : Do not raise an error, if the parsing of the name of the purchase order line doesn't match

### DIFF
--- a/grap_qweb_report/models/product_product.py
+++ b/grap_qweb_report/models/product_product.py
@@ -18,10 +18,11 @@ class ProductProduct(models.Model):
         )
         if len(supplierinfos) <= 1:
             return supplierinfos
+
         # Try to guess supplierinfo, from the code set in the order line name
-        regex_result = re.search(r"\[(\w+)\].*", order_line.name).groups()
-        if len(regex_result) == 1:
-            product_code = regex_result[0]
+        regex_result = re.search(r"\[(.+)\].*", order_line.name)
+        if regex_result and len(regex_result.groups()) == 1:
+            product_code = regex_result.groups()[0]
             supplierinfos = supplierinfos.filtered(
                 lambda x: x.product_code == product_code
             )


### PR DESCRIPTION


[FIX] allow special chars in the product code. (replace '\w+' by '.+')