### PR TITLE
Remove useless dependencies on grap_change_views_mrp

### DIFF
--- a/grap_change_views_mrp/__manifest__.py
+++ b/grap_change_views_mrp/__manifest__.py
@@ -13,16 +13,8 @@
         "mrp",
         "purchase",
         "sale_mrp",
-        # "mrp_bom_cost",
         # OCA
-        # "mrp_bom_component_menu",
-        # "mrp_auto_assign",
         "mrp_bom_note",
-        # "mrp_bom_tracking",
-        # "mrp_production_grouped_by_product",
-        # "mrp_production_note",
-        # "mrp_warehouse_calendar",
-        # "product_mrp_info",
         "web_widget_numeric_step",
         "mrp_bom_widget_section_and_note_one2many",
         # GRAP


### PR DESCRIPTION
~~Le seul champ "notes" n'est pas utilisé~~
En fait on va l'utiliser au lieu des champs descriptions de mrp_business donc on garde et supprime le reste
