### PR TITLE
[FIX] grap_change_access : depends on 'mrp'. (see ir.model.access.csv)

### DIFF
--- a/grap_change_access/__manifest__.py
+++ b/grap_change_access/__manifest__.py
@@ -12,6 +12,7 @@
     "website": "https://github.com/grap/grap-odoo-custom",
     "license": "AGPL-3",
     "depends": [
+        "mrp",
         "sales_team",
         "point_of_sale",
         "purchase",


### PR DESCRIPTION
Fix bad dependency introduced here https://github.com/grap/grap-odoo-custom/pull/270

