### PR TITLE
[FIX] main_seller - adjust depends and temp function

### DIFF
--- a/grap_change_views_product/views/view_product_product_form.xml
+++ b/grap_change_views_product/views/view_product_product_form.xml
@@ -159,6 +159,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                                     <field name="standard_price_tax_included" string="Cost Price (VAT Incl.)"
                                         groups="base.group_erp_manager" widget="monetary" options="{'display_currency': 'currency_id', 'field_digits': True}"/>
                                     <field name="product_main_seller_partner_id"/>
+                                    <field name="diff_product_main_first_seller" groups="base.group_no_one"/>
+                                    <button name="set_main_seller" string="⇒ Calculate Main supplier"
+                                        type="object" class="oe_link"
+                                        attrs="{'invisible': [('diff_product_main_first_seller', '=', False)]}"
+                                        help="Calculate Main supplier with first seller on suppliers info list."/>
                                     <field name="fiscal_classification_id" quick_create="false" required="1"/>
                                 </group>
                                 <group string="Sale">

--- a/product_main_seller/i18n/fr.po
+++ b/product_main_seller/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-17 10:29+0000\n"
-"PO-Revision-Date: 2023-02-17 10:29+0000\n"
+"POT-Creation-Date: 2024-03-04 15:52+0000\n"
+"PO-Revision-Date: 2024-03-04 15:52+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,29 +21,19 @@ msgid "By Main Vendor"
 msgstr "Par Fournisseur·e principal·e"
 
 #. module: product_main_seller
-#: model:ir.model.fields,help:product_main_seller.field_product_product__main_seller_partner_id
-#: model:ir.model.fields,help:product_main_seller.field_product_product__main_seller_variant_partner_id
-#: model:ir.model.fields,help:product_main_seller.field_product_template__main_seller_partner_id
-#: model:ir.model.fields,help:product_main_seller.field_product_template__main_seller_variant_partner_id
-msgid "Deprecated"
+#: model_terms:ir.ui.view,arch_db:product_main_seller.view_product_main_seller_form_2
+msgid "Calculate Main supplier with first seller on suppliers info list."
+msgstr "Défini læ Fournisseur·e principal·e avec la première ligne dans les infos fournisseurs."
+
+#. module: product_main_seller
+#: model:ir.model.fields,field_description:product_main_seller.field_product_product__diff_product_main_first_seller
+msgid "Diff Product Main First Seller"
 msgstr ""
 
 #. module: product_main_seller
 #: model:ir.model.fields,field_description:product_main_seller.field_product_product__product_main_seller_partner_id
 msgid "Main Product Seller Partner"
 msgstr "Fournisseur·e principal·e"
-
-#. module: product_main_seller
-#: model:ir.model.fields,field_description:product_main_seller.field_product_product__main_seller_partner_id
-#: model:ir.model.fields,field_description:product_main_seller.field_product_template__main_seller_partner_id
-msgid "Main Seller Partner"
-msgstr "Fournisseur·e principal·e"
-
-#. module: product_main_seller
-#: model:ir.model.fields,field_description:product_main_seller.field_product_product__main_seller_variant_partner_id
-#: model:ir.model.fields,field_description:product_main_seller.field_product_template__main_seller_variant_partner_id
-msgid "Main Seller Variant Partner"
-msgstr ""
 
 #. module: product_main_seller
 #: model_terms:ir.ui.view,arch_db:product_main_seller.view_product_main_seller_form_2
@@ -69,3 +59,8 @@ msgstr "Mettez la ligne d'information fournisseur·e en première position pour 
 #: model:ir.model,name:product_main_seller.model_product_supplierinfo
 msgid "Supplier Pricelist"
 msgstr "Liste de prix du fournisseur·e"
+
+#. module: product_main_seller
+#: model_terms:ir.ui.view,arch_db:product_main_seller.view_product_main_seller_form_2
+msgid "⇒ Calculate Main supplier"
+msgstr "⇒ Définir læ Fournisseur·e principal·e"

--- a/product_main_seller/models/product_product.py
+++ b/product_main_seller/models/product_product.py
@@ -8,6 +8,10 @@ from odoo import api, fields, models
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
+    diff_product_main_first_seller = fields.Boolean(
+        compute="_compute_diff_product_main_first_seller",
+    )
+
     product_main_seller_partner_id = fields.Many2one(
         comodel_name="res.partner",
         string="Main Product Seller Partner",
@@ -17,8 +21,31 @@ class ProductProduct(models.Model):
     )
 
     @api.multi
-    @api.depends("variant_seller_ids.sequence")
+    @api.depends("variant_seller_ids.sequence", "variant_seller_ids.name")
     def _compute_main_seller_partner_id(self):
         for prod in self:
             if len(prod.variant_seller_ids):
                 prod.product_main_seller_partner_id = prod.variant_seller_ids[0].name
+
+    # TEMP : In some case, main seller was not well calculated, and user
+    # needs to set it by hand
+    @api.multi
+    def set_main_seller(self):
+        self._compute_main_seller_partner_id()
+
+    @api.multi
+    @api.depends(
+        "variant_seller_ids.sequence",
+        "variant_seller_ids.name",
+        "product_main_seller_partner_id",
+    )
+    def _compute_diff_product_main_first_seller(self):
+        for prod in self:
+            if len(prod.variant_seller_ids):
+                if (
+                    prod.product_main_seller_partner_id
+                    != prod.variant_seller_ids[0].name
+                ):
+                    prod.diff_product_main_first_seller = True
+                else:
+                    prod.diff_product_main_first_seller = False

--- a/product_main_seller/views/view_product_product.xml
+++ b/product_main_seller/views/view_product_product.xml
@@ -17,6 +17,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <xpath expr="//group[@name='vendors']" position="before">
               <group string="Main Vendor" name="main_vendor">
                   <field name="product_main_seller_partner_id"/>
+                  <field name="diff_product_main_first_seller" groups="base.group_no_one"/>
+                  <button name="set_main_seller" string="⇒ Calculate Main supplier"
+                      type="object" class="oe_link"
+                      attrs="{'invisible': [('diff_product_main_first_seller', '=', False)]}"
+                      help="Calculate Main supplier with first seller on suppliers info list."/>
               </group>
             </xpath>
         </field>


### PR DESCRIPTION
- FIX main_seller changing if partner changes in supplier info (supplierinfo.name is the partner)
- TMP ? add a function to calculate main seller if it's different from first seller id → je n'ai pas réussi à le faire en requête sql, j'ai l'impression que ce n'est pas possible. Et c'est bien plus simple qu'un script python donc j'ai pris le parti de faire ça :) Ça permet manuellement aux actis de remettre bien fournisseur principal

![image](https://github.com/grap/grap-odoo-custom/assets/9005817/16497b98-f60e-4ec7-beaa-211998224b9b)
