### PR TITLE
12.0 fix main seller sql script

### DIFF
--- a/product_main_seller/__manifest__.py
+++ b/product_main_seller/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Product Main Seller",
     "summary": "Product Attribute - Main seller for a product",
-    "version": "12.0.1.1.6",
+    "version": "12.0.1.2.0",
     "category": "GRAP - Custom",
     "author": "GRAP",
     "website": "https://github.com/grap/grap-odoo-custom",

--- a/product_main_seller/migrations/12.0.1.2.0/post-migration.py
+++ b/product_main_seller/migrations/12.0.1.2.0/post-migration.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2024 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        WITH numbered_supplierinfos as (
+            SELECT *, ROW_number() over (
+                partition BY product_tmpl_id
+                ORDER BY sequence, min_qty desc, price
+            ) as row_number
+            FROM product_supplierinfo
+        ),
+
+        first_supplierinfos as (
+            SELECT * from numbered_supplierinfos
+            WHERE row_number = 1
+        )
+
+        UPDATE product_product pp
+        SET product_main_seller_partner_id = first_supplierinfos.name
+        FROM first_supplierinfos
+        WHERE pp.product_tmpl_id = first_supplierinfos.product_tmpl_id
+        AND pp.product_main_seller_partner_id != first_supplierinfos.name;
+        """,
+    )

--- a/product_main_seller/models/product_product.py
+++ b/product_main_seller/models/product_product.py
@@ -17,7 +17,7 @@ class ProductProduct(models.Model):
     )
 
     @api.multi
-    @api.depends("variant_seller_ids.sequence")
+    @api.depends("variant_seller_ids.sequence", "variant_seller_ids.name")
     def _compute_main_seller_partner_id(self):
         for prod in self:
             if len(prod.variant_seller_ids):

--- a/product_main_seller/tests/test_seller.py
+++ b/product_main_seller/tests/test_seller.py
@@ -75,3 +75,10 @@ class TestSeller(TransactionCase):
             self.product_workplace.product_main_seller_partner_id.id,
             self.partner_azure.id,
         )
+
+    def test_04_update_supplierinfo(self):
+        self.product_acoustic.seller_ids.write({"name": self.partner_azure.id})
+        self.assertEqual(
+            self.product_acoustic.product_main_seller_partner_id.id,
+            self.partner_azure.id,
+        )

--- a/product_main_seller/tests/test_seller.py
+++ b/product_main_seller/tests/test_seller.py
@@ -82,3 +82,10 @@ class TestSeller(TransactionCase):
             self.product_acoustic.product_main_seller_partner_id.id,
             self.partner_azure.id,
         )
+
+    def test_05_unlink_supplierinfo(self):
+        self.product_acoustic.seller_ids.unlink()
+        self.assertEqual(
+            self.product_acoustic.product_main_seller_partner_id.id,
+            False,
+        )

--- a/product_main_seller/tests/test_seller.py
+++ b/product_main_seller/tests/test_seller.py
@@ -26,23 +26,16 @@ class TestSeller(TransactionCase):
             self.product_acoustic.product_variant_ids[0].variant_seller_ids[0].name,
         )
 
-    def test_02_replace_vendor(self):
-        self.product_acoustic.write({"seller_ids": [(5, 0)]})
+    def test_02_replace_supplierinfo(self):
         self.product_acoustic.write(
-            {
-                "seller_ids": [
-                    (0, 0, {"name": self.partner_azure.id}),
-                ]
-            }
+            {"seller_ids": [(5, 0, 0), (0, 0, {"name": self.partner_azure.id})]}
         )
         self.assertEqual(
             self.product_acoustic.product_main_seller_partner_id.id,
             self.partner_azure.id,
         )
 
-    def test_03_add_vendor(self):
-        # Add one supplierinfo at the end
-        # -- For product without vendor
+    def test_03_add_supplierinfo_no_existing_supplierinfo(self):
         self.product_without_seller_desk.write(
             {
                 "seller_ids": [
@@ -54,7 +47,9 @@ class TestSeller(TransactionCase):
             self.product_without_seller_desk.product_main_seller_partner_id.id,
             self.partner_azure.id,
         )
-        # -- For product who had vendor
+
+    def test_03_add_supplierinfo_low_sequence(self):
+        self.product_workplace.seller_ids.write({"sequence": 1})
         self.product_workplace.write(
             {
                 "seller_ids": [
@@ -63,6 +58,20 @@ class TestSeller(TransactionCase):
             }
         )
         self.assertNotEqual(
+            self.product_workplace.product_main_seller_partner_id.id,
+            self.partner_azure.id,
+        )
+
+    def test_03_add_supplierinfo_high_sequence(self):
+        self.product_workplace.seller_ids.write({"sequence": 1000})
+        self.product_workplace.write(
+            {
+                "seller_ids": [
+                    (0, 0, {"sequence": 100, "name": self.partner_azure.id}),
+                ]
+            }
+        )
+        self.assertEqual(
             self.product_workplace.product_main_seller_partner_id.id,
             self.partner_azure.id,
         )


### PR DESCRIPTION
supersed : #360

Bah j'en ai bien chié des rondelles de chapeaux  pendant 3h !

Finament, c'est cet article qui m'a sauvé : https://learnsql.com/blog/sql-join-only-first-row/
c'est la partie "solution 2" qui nous intéresse. J'avais déjà joué avec ROW_number qq fois, mais j'ignorais l'existance de "with" qu'est plutot bien pratique.

Exécuté sur base de test : 
 
**Sur GRAP :** 
- 1722 correctifs 
- sachant qu'il y a 171081 product_supplierinfo et 178282 product_product

**Sur CAAP**
- 39 correctifs
- sachant qu'il y a 4293 product_supplierinfo et 4477 product_product

ça me semble cohérent.
