### PR TITLE
[12.0][IMP] Choosing all sales in sale grouped

### DIFF
--- a/mrp_sale_grouped/i18n/fr.po
+++ b/mrp_sale_grouped/i18n/fr.po
@@ -139,6 +139,11 @@ msgid "Is Follower"
 msgstr "Est un abonné"
 
 #. module: mrp_sale_grouped
+#: model_terms:ir.ui.view,arch_db:mrp_sale_grouped.view_sale_order_search
+msgid "Last 31 days"
+msgstr "31 derniers jours"
+
+#. module: mrp_sale_grouped
 #: model:ir.model.fields,field_description:mrp_sale_grouped.field_mrp_sale_grouped____last_update
 #: model:ir.model.fields,field_description:mrp_sale_grouped.field_report_mrp_sale_grouped_report_sale_grouped____last_update
 #: model:ir.model.fields,field_description:mrp_sale_grouped.field_sale_grouped_wizard____last_update

--- a/mrp_sale_grouped/views/view_mrp_sale_grouped.xml
+++ b/mrp_sale_grouped/views/view_mrp_sale_grouped.xml
@@ -101,7 +101,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                       ℹ️ Sales contains severals products that don't have any associated bill of material. Access them with the smart button on the right.
                     </div>
                     <group>
-                        <field name="order_ids" nolabel="1" widget="many2many">
+                        <field name="order_ids" nolabel="1" context="{'search_default_last_31_days_sale': 1}" widget="many2many" domain="[('state', '!=', 'cancel'), ('state', '!=', 'done')]">
                             <tree>
                               <field name="name"/>
                               <field name="date_order"/>

--- a/mrp_sale_grouped/views/view_mrp_sale_grouped.xml
+++ b/mrp_sale_grouped/views/view_mrp_sale_grouped.xml
@@ -101,7 +101,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                       ℹ️ Sales contains severals products that don't have any associated bill of material. Access them with the smart button on the right.
                     </div>
                     <group>
-                        <field name="order_ids" nolabel="1" widget="many2many" domain="['|', ('state', '=', 'sent'), ('state', '=', 'draft')]">
+                        <field name="order_ids" nolabel="1" widget="many2many">
                             <tree>
                               <field name="name"/>
                               <field name="date_order"/>

--- a/mrp_sale_grouped/views/view_sale_order.xml
+++ b/mrp_sale_grouped/views/view_sale_order.xml
@@ -16,4 +16,15 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         </field>
     </record>
 
+    <record id="view_sale_order_search" model="ir.ui.view">
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.view_sales_order_filter"/>
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='activities_upcoming_all']" position="after">
+                <separator/>
+                <filter string="Last 31 days" name="last_31_days_sale" domain="[('date_order', '&gt;=', (context_today() - datetime.timedelta(days=31)).strftime('%Y-%m-%d'))]"/>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
[Ticket](https://erp.grap.coop/web#id=1132&action=2148&active_id=4&model=project.task&view_type=form&menu_id=1673)

Use case : en fait on veut pouvoir choisir aussi les ventes confirmées, par exemple des ventes issues de la eboutique