### PR TITLE
[FIX] mrp_business: include mrp_product_produce_delay_in_hour as a de…

### DIFF
--- a/mrp_business/__manifest__.py
+++ b/mrp_business/__manifest__.py
@@ -13,6 +13,7 @@
     "license": "AGPL-3",
     "depends": [
         "mrp",
+        "mrp_product_produce_delay_in_hour",
     ],
     "demo": [
         "demo/product.xml",


### PR DESCRIPTION
…pendency because that module introduces produce_delay and produce_delay_in_hour fields on product.template, that are initialized by a migration script present in mrp_business