### PR TITLE
[16.0][FIX] mrp_bom_weight_field_position

### DIFF
--- a/mrp_bom_weight/views/view_mrp_bom.xml
+++ b/mrp_bom_weight/views/view_mrp_bom.xml
@@ -14,7 +14,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="model">mrp.bom</field>
         <field name="inherit_id" ref="mrp.mrp_bom_form_view" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='product_uom_id']/.." position="after">
+            <xpath expr="//group/group" position="inside">
               <field name="display_set_quantity_with_net_quantities" invisible="1"/>
               <label for="bom_components_total_net_weight"/>
               <div>


### PR DESCRIPTION
et oui mon cher Jamy car des `product_uom_id` ,yen a ailleurs et donc ça fait du caca 

[id task 1603](https://erp.grap.coop/web#id=1603&action=2148&active_id=40&model=project.task&view_type=form&menu_id=1673)