### PR TITLE
[FIX] fermente_cooperative_directory: avoid error for people that are…

### DIFF
--- a/fermente_cooperative_directory/models/hr_employee.py
+++ b/fermente_cooperative_directory/models/hr_employee.py
@@ -8,5 +8,5 @@ class HrEmployee(models.Model):
     _inherit = "hr.employee"
 
     is_displayed_in_directory = fields.Boolean(
-        string="Displayed in Directory", default=True
+        string="Displayed in Directory", default=True, groups="hr.group_hr_user"
     )


### PR DESCRIPTION
… not member of group_hr_user, to have an error, because data are not fetched.

Ref : weird comment : https://github.com/odoo/odoo/blob/16.0/addons/hr/models/hr_employee.py#L21